### PR TITLE
replace specific python interpreter path with reference to /usr/bin/env

### DIFF
--- a/ccat
+++ b/ccat
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.6
+#!/usr/bin/env python
 # Emacs, this is -*- python -*-
 
 import pygments


### PR DESCRIPTION
to determine appropriate python to use.  necessary when the python of
choice is not the one in /usr/bin
